### PR TITLE
feat: add ability to set custom java path to use when running jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
       ls_path = nil, -- 默认使用 ~/.vscode/extensions/vmware.vscode-spring-boot-x.xx.x
       jdtls_name = "jdtls",
       log_file = nil,
+      java_cmd = nil,
     })
   ```
 

--- a/README_en.md
+++ b/README_en.md
@@ -46,6 +46,7 @@ Integrate some features from the [VScode Spring Boot](https://marketplace.visual
       ls_path = nil, -- defaults to ~/.vscode/extensions/vmware.vscode-spring-boot-x.xx.x
       jdtls_name = "jdtls",
       log_file = nil,
+      java_cmd = nil, -- by default will try to get java 17+ path by using JAVA_HOME. If set, this will use the value here as the java command
     })
   ```
 

--- a/lua/spring_boot/launch.lua
+++ b/lua/spring_boot/launch.lua
@@ -39,7 +39,7 @@ local logfile = function(rt_dir)
   return lf or "/dev/null"
 end
 
-local function bootls_cmd(rt_dir)
+local function bootls_cmd(rt_dir, java_cmd)
   local boot_path = bootls_path()
   if not boot_path then
     vim.notify("Spring Boot LS is not installed", vim.log.levels.WARN)
@@ -50,7 +50,7 @@ local function bootls_cmd(rt_dir)
   table.insert(boot_classpath, boot_path .. "/BOOT-INF/lib/*")
 
   local cmd = {
-    util.java_bin(),
+    java_cmd or util.java_bin(),
     "-XX:TieredStopAtLevel=1",
     "-Xmx1G",
     "-XX:+UseZGC",
@@ -116,7 +116,7 @@ M.setup = function(_)
   }
   ls_config.capabilities = capabilities
   local rt_dir = config.server.root_dir or root_dir()
-  ls_config.cmd = config.server.cmd or bootls_cmd(rt_dir)
+  ls_config.cmd = config.server.cmd or bootls_cmd(rt_dir, config.java_cmd)
   if not ls_config.cmd then
     return
   end


### PR DESCRIPTION
By default this plugin uses `JAVA_HOME` to find the correct java path to use. I frequently change my `JAVA_HOME` variable as I work so having the ability to statically set what the jdk 17+ path is would be really helpful to me and probably others.

This PR is to make setting it as simple as updating the config with the path:
```lua
require("spring_boot").setup({
    java_cmd = "/path/to/java17/bin/java",
})
```