### PR TITLE
fix:解决开启inlay hints功能时，neovim会报Invalid 'col': out of range的问题，关闭sprin…

### DIFF
--- a/lua/spring_boot/java_data.lua
+++ b/lua/spring_boot/java_data.lua
@@ -2,6 +2,7 @@ local M = {}
 local jdtls = require("spring_boot.jdtls")
 
 M.register_java_data_service = function(client)
+  client.handlers["textDocument/inlayHint"] = function()end
   client.handlers["sts/javaType"] = function(_, result)
     return jdtls.execute_command("sts.java.type", result)
   end


### PR DESCRIPTION
…g-boot的textDocument/inlayHint，保留jdtls的
![1723191277062](https://github.com/user-attachments/assets/2b60ee58-37fb-4d00-80dd-4be9fe6d896e)
