### PR TITLE
feat: add the rest of handlers in java_data.lua

### DIFF
--- a/lua/spring_boot/java_data.lua
+++ b/lua/spring_boot/java_data.lua
@@ -20,15 +20,11 @@ M.register_java_data_service = function(client)
   end
 
   client.handlers["sts/javaSearchTypes"] = function(_, result)
-    -- TODO
-    print("sts/javaSearchTypes")
-    print(vim.inspect(result))
+    return jdtls.execute_command("sts.java.search.types", result)
   end
 
   client.handlers["sts/javaSearchPackages"] = function(_, result)
-    -- TODO
-    print("sts/javaSearchPackages")
-    print(vim.inspect(result))
+    return jdtls.execute_command("sts.java.search.packages", result)
   end
 
   client.handlers["sts/javaSubTypes"] = function(_, result)
@@ -36,13 +32,15 @@ M.register_java_data_service = function(client)
   end
 
   client.handlers["sts/javaSuperTypes"] = function(_, result)
-    -- TODO
-    print("sts/javaSuperTypes")
-    print(vim.inspect(result))
+    return jdtls.execute_command("sts.java.hierarchy.supertypes", result)
   end
 
   client.handlers["sts/javaCodeComplete"] = function(_, result)
     return jdtls.execute_command("sts.java.code.completions", result)
+  end
+
+  client.handlers["sts/project/gav"] = function(_, result)
+    return jdtls.execute_command("sts.project.gav", result)
   end
 end
 


### PR DESCRIPTION
This pull request adds the following handlers:
1.  `sts/javaSearchTypes` (was present as TODO)
2. `sts/javaSearchPackages` (was present as TODO)
3. `sts/javaSuperTypes` (was present as TODO)
4. `sts/project/gav` (was missing)

The missing handlers were taken from [java-data.ts](https://github.com/spring-projects/spring-tools/blob/main/vscode-extensions/commons-vscode/src/java-data.ts) from the vscode spring tools extension.

I noticed that both `sts/javaSearchPackages` and `sts/javaSearchTypes` are triggered when trying to autocomplete `logging.level.` (and so on) in `application.properties`.

**Before**
<img width="992" height="865" alt="without" src="https://github.com/user-attachments/assets/4de1777a-f632-4c48-a777-021f19a78e7d" />
**After**
<img width="956" height="452" alt="with" src="https://github.com/user-attachments/assets/56b7cedf-c9e9-4fc5-a99c-6012cc6c1493" />